### PR TITLE
feat: ContextMap replaced with ComponentApi

### DIFF
--- a/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
+++ b/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
@@ -87,6 +87,22 @@ exports[`renderToHTML should correctly parse async components 1`] = `
 </html>"
 `;
 
+exports[`renderToHTML should correctly perform sub renders async render rendered computer can access the context defined on the parent 1`] = `
+"<div class=\\"main\\">
+  <div><div>async foo</div><div>async foo</div><div>async bar</div></div>
+</div>"
+`;
+
+exports[`renderToHTML should correctly perform sub renders async render renders a simple component 1`] = `"<div><div>Hello World!</div></div>"`;
+
+exports[`renderToHTML should correctly perform sub renders sync render rendered computer can access the context defined on the parent 1`] = `
+"<div class=\\"main\\">
+  <div><div>foo</div><div>foo</div><div>bar</div></div>
+</div>"
+`;
+
+exports[`renderToHTML should correctly perform sub renders sync render renders a simple component 1`] = `"<div><div>Hello World!</div></div>"`;
+
 exports[`renderToHTML should correctly render jsx with arrays in between elements 1`] = `
 "<div>
   <h1>Header</h1>

--- a/__tests__/html-parser/render-to-html.test.tsx
+++ b/__tests__/html-parser/render-to-html.test.tsx
@@ -7,9 +7,9 @@ import {
 import { jsx, Fragment } from "../../src/jsx/jsx-runtime";
 import {
   ContextDefinition,
-  ContextMap,
+  ComponentApi,
   defineContext,
-} from "../../src/context-map/context-map";
+} from "../../src/component-api/component-api";
 import { ErrorBoundary } from "../../src/error-boundary/error-boundary";
 
 const sleep = (t: number) =>
@@ -241,9 +241,9 @@ describe("renderToHTML", () => {
     it("should correctly render jsx with context data", () => {
       const context = defineContext<{ title: string }>();
 
-      const Header: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { title } = contextMap.get(context);
+      const Header: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { title } = ctx.getOrFail(context);
         expect(title).toBe("This title is set via the context");
         return (
           <div>
@@ -260,8 +260,8 @@ describe("renderToHTML", () => {
         );
       };
 
-      const App: JSXTE.Component = (_, contextMap) => {
-        contextMap.set(context, { title: "This title is set via the context" });
+      const App: JSXTE.Component = (_, { ctx }) => {
+        ctx.set(context, { title: "This title is set via the context" });
 
         return (
           <html>
@@ -299,11 +299,11 @@ describe("renderToHTML", () => {
         buttonLabel: string;
       }>();
 
-      const Header: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { title } = contextMap.get(context);
+      const Header: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { title } = ctx.getOrFail(context);
 
-        contextMap.set(context, {
+        ctx.set(context, {
           title,
           inputPlaceholder:
             "This should not affect the rendered content, since this component has no children that consume this context.",
@@ -318,16 +318,16 @@ describe("renderToHTML", () => {
         );
       };
 
-      const Input: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { inputPlaceholder } = contextMap.get(context);
+      const Input: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { inputPlaceholder } = ctx.getOrFail(context);
         expect(inputPlaceholder).toBe("write here");
         return <input placeholder={inputPlaceholder} />;
       };
 
-      const Button: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { buttonLabel } = contextMap.get(context);
+      const Button: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { buttonLabel } = ctx.getOrFail(context);
         expect(buttonLabel).toBe("Submit");
         return <button>{buttonLabel}</button>;
       };
@@ -336,8 +336,8 @@ describe("renderToHTML", () => {
         return <>{[<Header />, <Input />, <Button />]}</>;
       };
 
-      const App: JSXTE.Component = (_, contextMap) => {
-        contextMap.set(context, {
+      const App: JSXTE.Component = (_, { ctx }) => {
+        ctx.set(context, {
           title: "This title is set via the context",
           buttonLabel: "Submit",
           inputPlaceholder: "write here",
@@ -379,11 +379,11 @@ describe("renderToHTML", () => {
         buttonLabel: string;
       }>();
 
-      const Header: JSXTE.Component = async (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { title } = contextMap.get(context);
+      const Header: JSXTE.Component = async (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { title } = ctx.getOrFail(context);
 
-        contextMap.set(context, {
+        ctx.set(context, {
           title,
           inputPlaceholder:
             "This should not affect the rendered content, since this component has no children that consume this context.",
@@ -399,17 +399,17 @@ describe("renderToHTML", () => {
         );
       };
 
-      const Input: JSXTE.Component = async (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { inputPlaceholder } = contextMap.get(context);
+      const Input: JSXTE.Component = async (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { inputPlaceholder } = ctx.getOrFail(context);
         expect(inputPlaceholder).toBe("write here");
         await sleep(50);
         return <input placeholder={inputPlaceholder} />;
       };
 
-      const Button: JSXTE.Component = async (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { buttonLabel } = contextMap.get(context);
+      const Button: JSXTE.Component = async (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { buttonLabel } = ctx.getOrFail(context);
         expect(buttonLabel).toBe("Submit");
         await sleep(50);
         return <button>{buttonLabel}</button>;
@@ -419,8 +419,8 @@ describe("renderToHTML", () => {
         return <>{[<Header />, <Input />, <Button />]}</>;
       };
 
-      const App: JSXTE.Component = async (_, contextMap) => {
-        contextMap.set(context, {
+      const App: JSXTE.Component = async (_, { ctx }) => {
+        ctx.set(context, {
           title: "This title is set via the context",
           buttonLabel: "Submit",
           inputPlaceholder: "write here",
@@ -461,27 +461,27 @@ describe("renderToHTML", () => {
         inputPlaceholder: string;
       }>();
 
-      const Header: JSXTE.Component = async (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { title } = contextMap.get(context);
+      const Header: JSXTE.Component = async (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { title } = ctx.getOrFail(context);
         expect(title).toBe("This title was overridden");
         return <h1>{title}</h1>;
       };
 
-      const Input: JSXTE.Component = async (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { inputPlaceholder } = contextMap.get(context);
+      const Input: JSXTE.Component = async (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { inputPlaceholder } = ctx.getOrFail(context);
         expect(inputPlaceholder).toBe("write here");
         await sleep(50);
         return <input placeholder={inputPlaceholder} />;
       };
 
-      const Content: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(context)).toBe(true);
-        const { title } = contextMap.get(context);
+      const Content: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(context)).toBe(true);
+        const { title } = ctx.getOrFail(context);
         expect(title).toBe("This title was set in the app component");
 
-        contextMap.update(context, {
+        ctx.update(context, {
           title: "This title was overridden",
         });
 
@@ -493,8 +493,8 @@ describe("renderToHTML", () => {
         );
       };
 
-      const App: JSXTE.Component = async (_, contextMap) => {
-        contextMap.set(context, {
+      const App: JSXTE.Component = async (_, { ctx }) => {
+        ctx.set(context, {
           title: "This title was set in the app component",
           inputPlaceholder: "write here",
         });
@@ -539,15 +539,15 @@ describe("renderToHTML", () => {
           context: ContextDefinition<T>;
           value: T;
         },
-        contextMap: ContextMap
+        { ctx }: ComponentApi
       ) => {
-        contextMap.set(props.context, props.value);
+        ctx.set(props.context, props.value);
         return <>{props.children}</>;
       };
 
-      const Header: JSXTE.Component = (_, contextMap) => {
-        expect(contextMap.has(myContext)).toBe(true);
-        const { title } = contextMap.get(myContext);
+      const Header: JSXTE.Component = (_, { ctx }) => {
+        expect(ctx.has(myContext)).toBe(true);
+        const { title } = ctx.getOrFail(myContext);
         expect(title).toBe("Provided title");
         return (
           <div>
@@ -599,8 +599,8 @@ describe("renderToHTML", () => {
     it("should correctly drill the prop data through multiple components", async () => {
       const store = defineContext<string>();
 
-      const Title: JSXTE.Component = (_, contextMap) => {
-        const title = contextMap.get(store);
+      const Title: JSXTE.Component = (_, { ctx }) => {
+        const title = ctx.get(store);
         return <p>{title}</p>;
       };
 
@@ -610,10 +610,10 @@ describe("renderToHTML", () => {
           value: T;
           sleep?: boolean;
         }>,
-        contextMap: ContextMap
+        { ctx }: ComponentApi
       ) => {
         if (props.sleep) await sleep(Math.random() * 1000);
-        contextMap.set(props.context, props.value);
+        ctx.set(props.context, props.value);
         return <>{props.children}</>;
       };
 
@@ -667,8 +667,8 @@ describe("renderToHTML", () => {
     it("close-by providers should not interfere with each other", async () => {
       const store = defineContext<string>();
 
-      const Title: JSXTE.Component = (_, contextMap) => {
-        const title = contextMap.get(store);
+      const Title: JSXTE.Component = (_, { ctx }) => {
+        const title = ctx.getOrFail(store);
         return <p>{title}</p>;
       };
 
@@ -678,10 +678,10 @@ describe("renderToHTML", () => {
           value: T;
           sleep?: number;
         }>,
-        contextMap: ContextMap
+        { ctx }: ComponentApi
       ) => {
         if (props.sleep) await sleep(props.sleep);
-        contextMap.set(props.context, props.value);
+        ctx.set(props.context, props.value);
         return <>{props.children}</>;
       };
 
@@ -720,25 +720,25 @@ describe("renderToHTML", () => {
 
     it("correctly handles encapsulated providers", () => {
       const makeContextWithProvider = <T,>() => {
-        const ctx = defineContext<T>();
+        const dctx = defineContext<T>();
 
         return {
-          context: ctx,
+          context: dctx,
           Provider: (
             props: JSXTE.PropsWithChildren<{
               value: T;
             }>,
-            contextMap: ContextMap
+            { ctx }: ComponentApi
           ) => {
-            contextMap.set(ctx, props.value);
+            ctx.set(dctx, props.value);
             return <>{props.children}</>;
           },
           Consumer: (
             props: { render: (value?: T) => JSX.Element },
-            contextMap: ContextMap
+            { ctx }: ComponentApi
           ) => {
-            if (contextMap.has(ctx)) {
-              const value = contextMap.get(ctx);
+            if (ctx.has(dctx)) {
+              const value = ctx.get(dctx);
               return <>{props.render(value)}</>;
             } else {
               return <>{props.render()}</>;
@@ -802,14 +802,14 @@ describe("renderToHTML", () => {
 
   describe("ErrorBoundary", () => {
     class FallbackBoundary extends ErrorBoundary {
-      render(props: JSXTE.ElementProps, contextMap: ContextMap) {
+      render(props: JSXTE.ElementProps, contextMap: ComponentApi) {
         return <>{props.children}</>;
       }
 
       onError(
         error: unknown,
         originalProps: JSXTE.ElementProps,
-        contextMap: ContextMap
+        contextMap: ComponentApi
       ): JSX.Element {
         return <h1>Oops. Something went wrong.</h1>;
       }
@@ -977,6 +977,118 @@ describe("renderToHTML", () => {
       const html = await renderToHtmlAsync(<App />);
 
       expect(html).toMatchSnapshot();
+    });
+  });
+
+  describe("should correctly perform sub renders", () => {
+    describe("sync render", () => {
+      it("renders a simple component", () => {
+        const App = (_: {}, componentApi: ComponentApi) => {
+          const content = componentApi.render(<div>Hello World!</div>);
+          return <div>{content}</div>;
+        };
+
+        const html = renderToHtml(<App />);
+
+        expect(html).toMatchSnapshot();
+      });
+
+      it("rendered computer can access the context defined on the parent", () => {
+        const myCtx = defineContext<{ foo: string }>();
+
+        const PrintFoo = (_: {}, componentApi: ComponentApi) => {
+          const foo = componentApi.ctx.getOrFail(myCtx).foo;
+          return <div>{foo}</div>;
+        };
+
+        const Foos = (_: {}, componentApi: ComponentApi) => {
+          const foo1 = componentApi.render(<PrintFoo />);
+          const foo2 = componentApi.render(<PrintFoo />);
+
+          componentApi.ctx.set(myCtx, { foo: "bar" });
+
+          const foo3 = componentApi.render(<PrintFoo />);
+
+          return (
+            <div>
+              {foo1}
+              {foo2}
+              {foo3}
+            </div>
+          );
+        };
+
+        const App = (_: {}, componentApi: ComponentApi) => {
+          componentApi.ctx.set(myCtx, { foo: "foo" });
+          return (
+            <div class="main">
+              <Foos />
+            </div>
+          );
+        };
+
+        const html = renderToHtml(<App />);
+
+        expect(html).toMatchSnapshot();
+      });
+    });
+
+    describe("async render", () => {
+      it("renders a simple component", async () => {
+        const HelloWorld = async () => {
+          await sleep(10);
+          return <div>Hello World!</div>;
+        };
+
+        const App = async (_: {}, componentApi: ComponentApi) => {
+          const content = await componentApi.renderAsync(<HelloWorld />);
+          return <div>{content}</div>;
+        };
+
+        const html = await renderToHtmlAsync(<App />);
+
+        expect(html).toMatchSnapshot();
+      });
+
+      it("rendered computer can access the context defined on the parent", async () => {
+        const myCtx = defineContext<{ foo: string }>();
+
+        const PrintFoo = async (_: {}, componentApi: ComponentApi) => {
+          await sleep(10);
+          const foo = componentApi.ctx.getOrFail(myCtx).foo;
+          return <div>{foo}</div>;
+        };
+
+        const Foos = async (_: {}, componentApi: ComponentApi) => {
+          const foo1 = await componentApi.renderAsync(<PrintFoo />);
+          const foo2 = await componentApi.renderAsync(<PrintFoo />);
+
+          componentApi.ctx.set(myCtx, { foo: "async bar" });
+
+          const foo3 = await componentApi.renderAsync(<PrintFoo />);
+
+          return (
+            <div>
+              {foo1}
+              {foo2}
+              {foo3}
+            </div>
+          );
+        };
+
+        const App = (_: {}, componentApi: ComponentApi) => {
+          componentApi.ctx.set(myCtx, { foo: "async foo" });
+          return (
+            <div class="main">
+              <Foos />
+            </div>
+          );
+        };
+
+        const html = await renderToHtmlAsync(<App />);
+
+        expect(html).toMatchSnapshot();
+      });
     });
   });
 });

--- a/__tests__/utilities/memo.test.tsx
+++ b/__tests__/utilities/memo.test.tsx
@@ -1,7 +1,7 @@
 import {
   defineContext,
-  type ContextMap,
-} from "../../src/context-map/context-map";
+  type ComponentApi,
+} from "../../src/component-api/component-api";
 import {
   renderToHtml,
   renderToHtmlAsync,
@@ -75,12 +75,12 @@ describe("memo", () => {
   it("memoized components should have access to the context of it's parent", () => {
     const Context = defineContext<{ foo: string }>();
 
-    const MemoizedComponent = memo((_: {}, context) => {
-      return <h1>{context.get(Context).foo}</h1>;
+    const MemoizedComponent = memo((_: {}, { ctx }) => {
+      return <h1>{ctx.getOrFail(Context).foo}</h1>;
     });
 
-    const Root = (_: {}, context: ContextMap) => {
-      context.set(Context, { foo: "Hello" });
+    const Root = (_: {}, { ctx }: ComponentApi) => {
+      ctx.set(Context, { foo: "Hello" });
 
       return (
         <div id="root">
@@ -97,8 +97,8 @@ describe("memo", () => {
   it("children of the memoized components should have access to the top level context", () => {
     const Context = defineContext<{ foo: string }>();
 
-    const MemoChild = (_: {}, context: ContextMap) => {
-      return <h1>{context.get(Context).foo}</h1>;
+    const MemoChild = (_: {}, { ctx }: ComponentApi) => {
+      return <h1>{ctx.getOrFail(Context).foo}</h1>;
     };
 
     const MemoizedComponent = memo((_: {}, context) => {
@@ -109,7 +109,7 @@ describe("memo", () => {
       );
     });
 
-    const MemoParent = (_: {}, context: ContextMap) => {
+    const MemoParent = (_: {}, context: ComponentApi) => {
       return (
         <div>
           <MemoizedComponent />
@@ -117,8 +117,8 @@ describe("memo", () => {
       );
     };
 
-    const Root = (_: {}, context: ContextMap) => {
-      context.set(Context, { foo: "Hello" });
+    const Root = (_: {}, { ctx }: ComponentApi) => {
+      ctx.set(Context, { foo: "Hello" });
 
       return (
         <div id="root">

--- a/src/error-boundary/error-boundary.ts
+++ b/src/error-boundary/error-boundary.ts
@@ -1,4 +1,4 @@
-import type { ContextMap } from "../context-map/context-map";
+import type { ComponentApi } from "../component-api/component-api";
 
 export type ErrorBoundaryElement<P extends object = {}> = new (
   props: JSXTE.PropsWithChildren<P>
@@ -22,12 +22,12 @@ export abstract class ErrorBoundary<P extends object = {}> {
 
   abstract render(
     props: JSXTE.PropsWithChildren<P>,
-    contextMap: ContextMap
+    contextMap: ComponentApi
   ): JSX.Element | Promise<JSX.Element>;
 
   abstract onError(
     error: unknown,
     originalProps: JSXTE.PropsWithChildren<P>,
-    contextMap: ContextMap
+    contextMap: ComponentApi
   ): JSX.Element;
 }

--- a/src/html-parser/jsx-elem-to-html.ts
+++ b/src/html-parser/jsx-elem-to-html.ts
@@ -1,4 +1,4 @@
-import { ContextMap } from "../context-map/context-map";
+import { ComponentApi } from "../component-api/component-api";
 import { ErrorBoundary } from "../error-boundary/error-boundary";
 import { pad } from "../utilities/pad";
 import { mapAttributesToHtmlTagString } from "./attribute-to-html-tag-string";
@@ -8,7 +8,7 @@ const isSyncElem = (e: JSX.Element): e is JSXTE.SyncElement => true;
 const isTextNode = (e: JSX.Element): e is JSXTE.TextNodeElement =>
   "type" in e && e.type === "textNode";
 
-type InternalOptions = {
+export type RendererInternalOptions = {
   indent?: number;
   currentIndent?: number;
   attributeMap?: Record<string, string>;
@@ -16,11 +16,13 @@ type InternalOptions = {
 
 export const jsxElemToHtmlSync = (
   element: JSX.Element,
-  contextMap: ContextMap = ContextMap.create(),
-  options?: InternalOptions
+  _contextMap?: ComponentApi,
+  options?: RendererInternalOptions
 ): string => {
   const { attributeMap = {}, currentIndent = 0, indent = 2 } = options ?? {};
-  contextMap = ContextMap.clone(contextMap);
+  const contextMap = _contextMap
+    ? ComponentApi.clone(_contextMap)
+    : ComponentApi.create(options);
 
   if (!isSyncElem(element)) throw new Error("");
 
@@ -132,11 +134,13 @@ export const jsxElemToHtmlSync = (
 
 export const jsxElemToHtmlAsync = async (
   element: JSX.Element,
-  contextMap: ContextMap = ContextMap.create(),
-  options?: InternalOptions
+  _contextMap?: ComponentApi,
+  options?: RendererInternalOptions
 ): Promise<string> => {
   const { attributeMap = {}, currentIndent = 0, indent = 2 } = options ?? {};
-  contextMap = ContextMap.clone(contextMap);
+  const contextMap = _contextMap
+    ? ComponentApi.clone(_contextMap)
+    : ComponentApi.create(options);
 
   if (!isSyncElem(element)) throw new Error("");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,15 @@ export * from "./jsx/jsx.types";
 export * from "./jsx/prop-types/index";
 
 export { ErrorBoundary } from "./error-boundary/error-boundary";
-export { defineContext } from "./context-map/context-map";
+export { defineContext } from "./component-api/component-api";
 export { renderToHtml, renderToHtmlAsync } from "./html-parser/render-to-html";
 export { renderToStringTemplateTag } from "./string-template-parser/render-to-string-template-tag";
 export { memo } from "./utilities/memo";
 
-export type { ContextDefinition, ContextMap } from "./context-map/context-map";
+export type {
+  ContextDefinition,
+  ComponentApi,
+} from "./component-api/component-api";
 export type { AttributeBool, HTMLProps } from "./jsx/base-html-tag-props";
 export type { StringTemplateParserOptions } from "./string-template-parser/render-to-string-template-tag";
 export type { Crossorigin } from "./jsx/prop-types/shared/crossorigin";

--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -1,4 +1,4 @@
-import type { ContextMap } from "../context-map/context-map";
+import type { ComponentApi } from "../component-api/component-api";
 import type { ErrorBoundaryElement } from "../error-boundary/error-boundary";
 import type { Rewrap } from "../html-parser/types";
 
@@ -28,8 +28,8 @@ declare global {
       type: "tag";
       tag:
         | string
-        | ((props: ElementProps, contextMap: ContextMap) => Element)
-        | ((props: ElementProps, contextMap: ContextMap) => Promise<Element>)
+        | ((props: ElementProps, contextMap: ComponentApi) => Element)
+        | ((props: ElementProps, contextMap: ComponentApi) => Promise<Element>)
         | ErrorBoundaryElement;
       props: ElementProps;
     };
@@ -60,12 +60,12 @@ declare global {
 
     type Component<P extends object = {}> = (
       props: PropsWithChildren<P>,
-      contextMap: ContextMap
+      contextMap: ComponentApi
     ) => JSX.Element;
 
     type AsyncComponent<P extends object = {}> = (
       props: PropsWithChildren<P>,
-      contextMap: ContextMap
+      contextMap: ComponentApi
     ) => Promise<JSX.Element>;
 
     interface BaseHTMLTagProps {

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -1,4 +1,4 @@
-import type { ContextMap } from "../context-map/context-map";
+import type { ComponentApi } from "../component-api/component-api";
 
 type CreateElementProps = {
   [k: string]: any;
@@ -8,8 +8,8 @@ type CreateElementProps = {
 export const createElement = (
   tag:
     | string
-    | ((props: any, contextMap: ContextMap) => JSX.Element)
-    | ((props: any, contextMap: ContextMap) => Promise<JSX.Element>),
+    | ((props: any, contextMap: ComponentApi) => JSX.Element)
+    | ((props: any, contextMap: ComponentApi) => Promise<JSX.Element>),
   props?: CreateElementProps,
   ...children: Array<
     JSX.Element | string | number | Array<JSX.Element | string | number>

--- a/src/string-template-parser/jsx-elem-to-strings.ts
+++ b/src/string-template-parser/jsx-elem-to-strings.ts
@@ -1,4 +1,4 @@
-import { ContextMap } from "../context-map/context-map";
+import { ComponentApi } from "../component-api/component-api";
 import { ErrorBoundary } from "../error-boundary/error-boundary";
 import { mapAttributeName } from "./map-attribute-name";
 import { resolveElement } from "./resolve-element";
@@ -20,9 +20,9 @@ const concatToLastStringOrPush = (a: TagFunctionArgs, s?: string) => {
 export const jsxElemToTagFuncArgsSync = (
   element: JSX.Element,
   attributeMap: Record<string, string>,
-  contextMap: ContextMap = ContextMap.create()
+  contextMap: ComponentApi = ComponentApi.create()
 ): TagFunctionArgs => {
-  contextMap = ContextMap.clone(contextMap);
+  contextMap = ComponentApi.clone(contextMap);
 
   if (!isSyncElem(element)) throw new Error("");
 

--- a/src/utilities/memo.ts
+++ b/src/utilities/memo.ts
@@ -1,13 +1,13 @@
-import type { ContextMap } from "../context-map/context-map";
+import type { ComponentApi } from "../component-api/component-api";
 import { renderToHtml, renderToHtmlAsync } from "../html-parser/render-to-html";
 import { jsx, Fragment } from "../jsx-runtime";
 import { Cache } from "./cache";
 
-const ReplaceMap = <P extends { context: ContextMap }>(
+const ReplaceMap = <P extends { context: ComponentApi }>(
   props: JSXTE.PropsWithChildren<P>,
-  context: ContextMap
+  context: ComponentApi
 ) => {
-  context.replace(props.context);
+  context.ctx.replace(props.context.ctx);
   // @ts-ignore
   return jsx(Fragment, {}, props.children);
 };
@@ -26,7 +26,7 @@ const ReplaceMap = <P extends { context: ContextMap }>(
  * reflect those changes.
  */
 export const memo = <P extends object & { children?: any }>(
-  Component: (props: P, context: ContextMap) => JSX.Element,
+  Component: (props: P, context: ComponentApi) => JSX.Element,
   options?: {
     /** Time in milliseconds. Default: 15 minutes. */
     maxCacheAge?: number;
@@ -35,7 +35,10 @@ export const memo = <P extends object & { children?: any }>(
      * render this component. Default: `false`.
      */
     renderAsynchronously?: boolean;
-    /** Maximum number of cached entries to keep in memory. Default: 10. */
+    /**
+     * Maximum number of cached entries to keep in memory.
+     * Default: 10.
+     */
     maxCacheEntries?: number;
   }
 ) => {
@@ -50,7 +53,7 @@ export const memo = <P extends object & { children?: any }>(
   if (renderAsynchronously) {
     const MemoComponentAsync = async (
       props: P,
-      context: ContextMap
+      context: ComponentApi
     ): Promise<JSXTE.TextNodeElement> => {
       const { children, ...propsNoChildren } = props;
 
@@ -78,7 +81,7 @@ export const memo = <P extends object & { children?: any }>(
 
   const MemoComponent = (
     props: P,
-    context: ContextMap
+    context: ComponentApi
   ): JSXTE.TextNodeElement => {
     const { children, ...propsNoChildren } = props;
 


### PR DESCRIPTION
Replaced the `ContextMap` argument that was available to to all components with a new `ComponentApi`. Contexts can still be accessed via the new API, via the `ComponentApi.ctx` property. Additionally the new api provides a `render` method, which can be used similarly to the `renderToHtml`, but the context's data will get forwarded to the rendered components.