### PR TITLE
feat: improvements to the `renderToStringTemplateTag`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": false,
-  "printWidth": 80,
-  "jsdocPrintWidth": 65
-}

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,15 @@
+/**
+ * @type {import("prettier").Options}
+ */
+const config = {
+  bracketSpacing: true,
+  tabWidth: 2,
+  semi: true,
+  singleQuote: false,
+  printWidth: 80,
+  singleAttributePerLine: true,
+  plugins: ["./node_modules/prettier-plugin-jsdoc/dist/index.js"],
+  jsdocSingleLineComment: false,
+};
+
+export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,17 @@ export * from "./express/index";
 export * from "./jsx/jsx.types";
 export * from "./jsx/prop-types/index";
 
+export {
+  Interpolate,
+  InterpolateTag,
+} from "./string-template-parser/interpolate";
+export { DefaultTemplateArrayCache } from "./string-template-parser/default-cache";
 export { ErrorBoundary } from "./error-boundary/error-boundary";
 export { defineContext } from "./component-api/component-api";
-export { renderToHtml, renderToHtmlAsync } from "./html-parser/render-to-html";
+export {
+  renderToHtml,
+  renderToHtmlAsync,
+} from "./html-parser/render-to-html";
 export { renderToStringTemplateTag } from "./string-template-parser/render-to-string-template-tag";
 export { memo } from "./utilities/memo";
 
@@ -14,7 +22,10 @@ export type {
   ContextDefinition,
   ComponentApi,
 } from "./component-api/component-api";
-export type { AttributeBool, HTMLProps } from "./jsx/base-html-tag-props";
+export type {
+  AttributeBool,
+  HTMLProps,
+} from "./jsx/base-html-tag-props";
 export type { StringTemplateParserOptions } from "./string-template-parser/render-to-string-template-tag";
 export type { Crossorigin } from "./jsx/prop-types/shared/crossorigin";
 export type { RefererPolicy } from "./jsx/prop-types/shared/referer-policy";

--- a/src/string-template-parser/default-cache.ts
+++ b/src/string-template-parser/default-cache.ts
@@ -1,0 +1,36 @@
+import type { TemplateLiteralCache } from "./render-to-string-template-tag";
+
+const arrIsEqual = (
+  a: TemplateStringsArray,
+  b: TemplateStringsArray,
+) => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
+export class DefaultTemplateArrayCache
+  implements TemplateLiteralCache
+{
+  private entries: Array<TemplateStringsArray> = [];
+
+  set(templateArray: TemplateStringsArray) {
+    this.entries.push(templateArray);
+  }
+
+  get(
+    templateArray: TemplateStringsArray,
+  ): TemplateStringsArray | undefined {
+    for (let i = 0; i < this.entries.length; i++) {
+      if (arrIsEqual(this.entries[i]!, templateArray)) {
+        return this.entries[i];
+      }
+    }
+
+    return undefined;
+  }
+
+  clear() {
+    this.entries = [];
+  }
+}

--- a/src/string-template-parser/interpolate.ts
+++ b/src/string-template-parser/interpolate.ts
@@ -1,0 +1,93 @@
+/**
+ * Only fo use with the `renderToStringTemplateTag` render function.
+ *
+ * Whatever is passed to this component as children will be
+ * interpolated into the template string.
+ *
+ * Example
+ *
+ * ```tsx
+ *   function someFunction() {}
+ *
+ *   renderToStringTemplateTag(
+ *      html,
+ *      <div>
+ *          <Interpolate>
+ *              {someFunction}
+ *          </Interpolate>
+ *      </div>
+ *   );
+ *
+ *   // The above is equivalent to:
+ *
+ *   html`
+ *          <div>
+ *              ${someFunction}
+ *          </div>
+ * `;
+ * ```
+ */
+export class Interpolate {
+  /**
+   * @internal
+   */
+  static _isInterpolate(o: any): o is typeof Interpolate {
+    const canBeClass = typeof o === "function";
+    const isNotNull = o !== null;
+
+    if (!canBeClass || !isNotNull) return false;
+
+    const baseName = (o as any as typeof Interpolate)._baseName;
+    return baseName === this._baseName;
+  }
+
+  private static _baseName = "Interpolate";
+
+  constructor(props: { children?: any }) {}
+}
+
+/**
+ * Only fo use with the `renderToStringTemplateTag` render function.
+ *
+ * Whatever is passed to this component as children will be rendered
+ * using the tag function and interpolated into the template string.
+ *
+ * Example
+ *
+ * ```tsx
+ *   renderToStringTemplateTag(
+ *      html,
+ *      <div>
+ *          <InterpolateTag>
+ *              <span>Hello World</span>
+ *          </InterpolateTag>
+ *      </div>
+ *   );
+ *
+ *   // The above is equivalent to:
+ *
+ *   html`
+ *          <div>
+ *              ${html`<span>Hello World</span>`}
+ *          </div>
+ * `;
+ * ```
+ */
+export class InterpolateTag {
+  /**
+   * @internal
+   */
+  static _isInterpolateRender(o: any): o is typeof InterpolateTag {
+    const canBeClass = typeof o === "function";
+    const isNotNull = o !== null;
+
+    if (!canBeClass || !isNotNull) return false;
+
+    const baseName = (o as any as typeof InterpolateTag)._baseName;
+    return baseName === this._baseName;
+  }
+
+  private static _baseName = "InterpolateTag";
+
+  constructor(props: { children?: any }) {}
+}

--- a/src/string-template-parser/render-to-string-template-tag.ts
+++ b/src/string-template-parser/render-to-string-template-tag.ts
@@ -1,39 +1,77 @@
 /* eslint-disable max-len */
 import { jsxElemToTagFuncArgsSync } from "./jsx-elem-to-strings";
 import type { StringTemplateTag } from "./string-template-tag-type";
+import { toTemplateStringArray } from "./to-template-string-array";
+
+export interface TemplateLiteralCache {
+  get: (
+    templateStringsArray: TemplateStringsArray,
+  ) => TemplateStringsArray | undefined;
+  set: (templateStringsArray: TemplateStringsArray) => void;
+}
 
 export type StringTemplateParserOptions = {
   /**
-   * Mappings for html attribute names. Attributes defined in
-   * here will get renamed during the rendering to whatever is set.
+   * Mappings for html attribute names. Attributes defined in here
+   * will get renamed during the rendering to whatever is set.
    *
    * @example
    *   const options = {
-   *     attributeMap: { onclick: "@click" },
+   *   attributeMap: { onclick: "@click" },
    *   };
    *
    *   renderToStringTemplateTag(
-   *     html,
-   *     <button onclick={handle}>Click Me</button>,
-   *     options
+   *   html,
+   *   <button onclick={handle}>Click Me</button>,
+   *   options
    *   );
    *   // Will give the same result as
    *   html`<button @click="${handle}">Click Me</button>`;
    */
   attributeMap?: Record<string, string>;
+  /**
+   * Template literal tags have a specific behavior to them, the
+   * `TemplateStringsArray` is memoized for evaluations of the same
+   * template literal. This is possible because the
+   * `TemplateStringsArray` contains only parts of the template
+   * literal that are not dynamic, and will never change.
+   *
+   * JSXTE templates can produce different `TemplateStringsArray` so
+   * similar behavior is not possible.
+   *
+   * By providing a cache object you can simulate a similar behavior
+   * to real template literals. Cache object is expected to be an
+   * object with a `get` and `set` method.
+   *
+   * The `get` method shall compare the given `TemplateStringsArray`
+   * to the ones in the cache and if a value that is deeply equal to
+   * it exists, return it.
+   *
+   * The `set` method shall store the given `TemplateStringsArray` in
+   * the cache.
+   */
+  cache?: TemplateLiteralCache;
 };
 
 export const renderToStringTemplateTag = <R>(
   tag: StringTemplateTag<R>,
   Component: JSX.Element,
-  options?: StringTemplateParserOptions
+  options: StringTemplateParserOptions = {},
 ) => {
-  const [templateStringArray, params] = jsxElemToTagFuncArgsSync(
-    Component,
-    options?.attributeMap ?? {}
-  );
+  const [tmpTsa, params] = jsxElemToTagFuncArgsSync(Component, {
+    ...options,
+    tag,
+  });
 
-  Object.assign(templateStringArray, { raw: [...templateStringArray] });
+  const templateStringArray = toTemplateStringArray(tmpTsa);
+
+  const cached = options?.cache?.get(templateStringArray as any);
+
+  if (cached) {
+    return tag(cached as any, ...params);
+  }
+
+  options?.cache?.set(templateStringArray as any);
 
   return tag(templateStringArray as any, ...params);
 };

--- a/src/string-template-parser/resolve-element.ts
+++ b/src/string-template-parser/resolve-element.ts
@@ -7,7 +7,7 @@ type AsArray<T> = [GetArrayFromUnion<T>] extends [never]
   ? GetNonArraysFromUnion<T>[]
   : Array<ArrayType<GetArrayFromUnion<T>> | GetNonArraysFromUnion<T>>;
 
-function asArray<T>(v: T): AsArray<T> {
+export function asArray<T>(v: T): AsArray<T> {
   if (Array.isArray(v)) {
     return v;
   } else {

--- a/src/string-template-parser/to-template-string-array.ts
+++ b/src/string-template-parser/to-template-string-array.ts
@@ -1,0 +1,16 @@
+export const toTemplateStringArray = (
+  orgArr: string[],
+): TemplateStringsArray => {
+  const templateStringArray =
+    orgArr.slice() as any as TemplateStringsArray;
+
+  Object.defineProperty(templateStringArray, "raw", {
+    value: orgArr,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+  Object.freeze(templateStringArray);
+
+  return templateStringArray;
+};


### PR DESCRIPTION
Multiple improvements to the render function for string template tags:

- New `<Interpolate>` and `<InterpolateTag>` components. Contents of those will be interpolated into the string template as is for Interpolate, and as a rendered tag for InterpolateTag (see JSDoc comments on those for more details.
- Falsy values passed to the attributes will prevent those attributes from being added at all, while truthy values will cause those attributes to be added with their names as values.
- Caching mechanism to allow for the same input to provide the exact same TemplateStringArray reference to the tag on every call.