### PR TITLE
feat: optimized the code (for..let loops over for..of, faster string join algo, etc.)

### DIFF
--- a/src/component-api/component-api.ts
+++ b/src/component-api/component-api.ts
@@ -13,39 +13,39 @@ export class ContextAccessor {
   constructor(private map: Map<symbol, unknown> = new Map()) {}
 
   /**
-   * Retrieve the context data for the specified context. If the
-   * context has never been set by any of this component
-   * ancestors an error will be thrown.
+   * Retrieve the context data for the specified context. If the context has
+   * never been set by any of this component ancestors an error will be thrown.
    */
   public getOrFail<T>(ref: ContextDefinition<T>): T {
     const value = this.map.get(ref.id);
 
     if (value === undefined) {
       throw new Error(
-        "Context not defined! Make sure the context is set before accessing it."
+        "Context not defined! Make sure the context is set before accessing it.",
       );
     }
 
     return value as T;
   }
 
-  /** Retrieve the context data for the specified context. */
+  /**
+   * Retrieve the context data for the specified context.
+   */
   public get<T>(ref: ContextDefinition<T>): T | undefined {
     const value = this.map.get(ref.id);
     return value as any;
   }
 
   /**
-   * Partially update the state of the context data. Works only
-   * for objects and can only be used if some context data is
-   * already set beforehand.
+   * Partially update the state of the context data. Works only for objects and
+   * can only be used if some context data is already set beforehand.
    *
-   * Updates to the context made with this method are only
-   * visible to this component and it's descendants.
+   * Updates to the context made with this method are only visible to this
+   * component and it's descendants.
    */
   public update<T extends object>(
     ref: ContextDefinition<T>,
-    updateData: Partial<T>
+    updateData: Partial<T>,
   ): void {
     const data = this.get(ref);
 
@@ -58,7 +58,9 @@ export class ContextAccessor {
       if (Array.isArray(data)) {
         const arr = Array.from(data);
 
-        for (const [key, value] of Object.entries(updateData)) {
+        const entries = Object.entries(updateData);
+        for (let i = 0; i < entries.length; i++) {
+          const [key, value] = entries[i]!;
           const index = Number(key);
           if (!isNaN(index)) arr[index] = value;
         }
@@ -69,7 +71,7 @@ export class ContextAccessor {
       }
     } else {
       throw new Error(
-        "Context data is not an object!. Partial updates are only possible for objects."
+        "Context data is not an object!. Partial updates are only possible for objects.",
       );
     }
   }
@@ -77,21 +79,22 @@ export class ContextAccessor {
   /**
    * Sets the context data for the specified context.
    *
-   * Changes to the context made with this method are only
-   * visible to this component and it's descendants.
+   * Changes to the context made with this method are only visible to this
+   * component and it's descendants.
    */
   public set<T>(ref: ContextDefinition<T>, data: T): void {
     this.map.set(ref.id, data);
   }
 
-  /** Check if the context data for the specified context is set. */
+  /**
+   * Check if the context data for the specified context is set.
+   */
   public has<T>(ref: ContextDefinition<T>): boolean {
     return this.map.has(ref.id);
   }
 
   /**
-   * Replaces this context entries with the entries of the
-   * context provided.
+   * Replaces this context entries with the entries of the context provided.
    *
    * @internal
    */
@@ -108,24 +111,26 @@ export class ComponentApi {
   public static clone(original: ComponentApi): ComponentApi {
     return new ComponentApi(
       original.attributeMap,
-      ContextAccessor.clone(original.ctx)
+      ContextAccessor.clone(original.ctx),
     );
   }
 
-  /** Access to the current context data. */
+  /**
+   * Access to the current context data.
+   */
   public ctx;
 
   private constructor(
     private attributeMap?: Record<string, string>,
-    accessor?: ContextAccessor
+    accessor?: ContextAccessor,
   ) {
     this.ctx = accessor ?? new ContextAccessor();
   }
 
   /**
-   * Renders the given JSX component to pure html as if it was a
-   * child of this component. All context available to this
-   * component will be available to the given component as well.
+   * Renders the given JSX component to pure html as if it was a child of this
+   * component. All context available to this component will be available to the
+   * given component as well.
    */
   public render(component: JSX.Element): string {
     return jsxElemToHtmlSync(component, this, {
@@ -134,13 +139,13 @@ export class ComponentApi {
   }
 
   public async renderAsync(
-    component: JSX.Element | Promise<JSX.Element>
+    component: JSX.Element | Promise<JSX.Element>,
   ): Promise<string> {
     const thisCopy = ComponentApi.clone(this);
     return Promise.resolve(component).then((c) =>
       jsxElemToHtmlAsync(c, thisCopy, {
         attributeMap: thisCopy.attributeMap,
-      })
+      }),
     );
   }
 }
@@ -152,7 +157,7 @@ export class ContextDefinition<T> {
     props: JSXTE.PropsWithChildren<{
       value: T;
     }>,
-    componentApi: ComponentApi
+    componentApi: ComponentApi,
   ) => {
     componentApi.ctx.set(this, props.value);
     return jsx("", { children: props.children });
@@ -162,7 +167,7 @@ export class ContextDefinition<T> {
     props: JSXTE.PropsWithChildren<{
       render: (value?: T) => JSX.Element;
     }>,
-    componentApi: ComponentApi
+    componentApi: ComponentApi,
   ) => {
     const value = componentApi.ctx.get(this);
     return props.render(value);

--- a/src/html-parser/attribute-to-html-tag-string.ts
+++ b/src/html-parser/attribute-to-html-tag-string.ts
@@ -2,7 +2,7 @@ import type { RendererHTMLAttributes } from "./types";
 
 export const attributeToHtmlTagString = ([key, value]: [
   string,
-  string | boolean | number | undefined
+  string | boolean | number | undefined,
 ]): string => {
   if (value === true) {
     return `${key}`;
@@ -14,7 +14,15 @@ export const attributeToHtmlTagString = ([key, value]: [
 };
 
 export const mapAttributesToHtmlTagString = (
-  attributes: RendererHTMLAttributes
+  attributes: RendererHTMLAttributes,
 ): string[] => {
-  return attributes.map(attributeToHtmlTagString).filter((e) => e);
+  const results: string[] = [];
+
+  for (let i = 0; i < attributes.length; i++) {
+    const attribute = attributes[i]!;
+    const html = attributeToHtmlTagString(attribute);
+    if (html.length > 0) results.push(html);
+  }
+
+  return results;
 };

--- a/src/html-parser/base-html-parser/base-html-parser.ts
+++ b/src/html-parser/base-html-parser/base-html-parser.ts
@@ -10,8 +10,9 @@ export class HTMLElementResolver {
 
   resolveAttributes(element: JSXTE.TagElement): RendererHTMLAttributes {
     const attributes: HTMLElementStruct["attributes"] = [];
-
-    for (const [key, prop] of Object.entries(element.props)) {
+    const entries = Object.entries(element.props);
+    for (let i = 0; i < entries.length; i++) {
+      const [key, prop] = entries[i]!;
       if (key !== "children") {
         attributes.push([mapAttributeName(key, this.attributeMap), prop]);
       }

--- a/src/string-template-parser/jsx-elem-to-strings.ts
+++ b/src/string-template-parser/jsx-elem-to-strings.ts
@@ -60,11 +60,7 @@ export const jsxElemToTagFuncArgsSync = (
           );
         }
 
-        return jsxElemToTagFuncArgsSync(
-          subElem,
-          options,
-          componentApi,
-        );
+        return jsxElemToTagFuncArgsSync(subElem, options, componentApi);
       } catch (e) {
         const fallbackElem = boundary.onError(
           e,
@@ -78,11 +74,7 @@ export const jsxElemToTagFuncArgsSync = (
           );
         }
 
-        return jsxElemToTagFuncArgsSync(
-          fallbackElem,
-          options,
-          componentApi,
-        );
+        return jsxElemToTagFuncArgsSync(fallbackElem, options, componentApi);
       }
     }
 
@@ -128,9 +120,13 @@ export const jsxElemToTagFuncArgsSync = (
     if (element.tag === "") {
       const results: TagFunctionArgs = [[], []];
 
-      for (const child of children) {
-        const [[first, ...strings], tagParams] =
-          jsxElemToTagFuncArgsSync(child, options, componentApi);
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i]!;
+        const [[first, ...strings], tagParams] = jsxElemToTagFuncArgsSync(
+          child,
+          options,
+          componentApi,
+        );
 
         concatToLastStringOrPush(results, first);
 
@@ -149,14 +145,10 @@ export const jsxElemToTagFuncArgsSync = (
       results[0].push(part1);
 
       const attrList = Object.entries(attributes);
-      for (const index in attrList) {
+      for (let index = 0; index < attrList.length; index++) {
         const [attrName, value] = attrList[index]!;
 
-        if (
-          value === false ||
-          value === null ||
-          value === undefined
-        ) {
+        if (value === false || value === null || value === undefined) {
           continue;
         }
 
@@ -171,9 +163,13 @@ export const jsxElemToTagFuncArgsSync = (
 
       concatToLastStringOrPush(results, part2);
 
-      for (const child of children) {
-        const [[first, ...strings], tagParams] =
-          jsxElemToTagFuncArgsSync(child, options, componentApi);
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i]!;
+        const [[first, ...strings], tagParams] = jsxElemToTagFuncArgsSync(
+          child,
+          options,
+          componentApi,
+        );
 
         concatToLastStringOrPush(results, first);
 

--- a/src/utilities/join.ts
+++ b/src/utilities/join.ts
@@ -1,0 +1,10 @@
+export function join(arr: string[], separator = "\n") {
+  let result = arr[0] ?? "";
+
+  const until = arr.length;
+  for (let i = 1; i < until; i++) {
+    result += separator + arr[i]!;
+  }
+
+  return result;
+}

--- a/src/utilities/pad.ts
+++ b/src/utilities/pad.ts
@@ -1,3 +1,0 @@
-export const pad = (length: number, char = " ") => {
-  return Array.from({ length }, () => char).join("");
-};


### PR DESCRIPTION
Added code optimizations:

1. Instead of `for..of` loops that rely on iterators used the good ol' `for..let i = 0;` loops which are much faster
2. Replaced all usages of `String.join()` with a much faster custom implementation
3. Reduced the amount of needless object instantiations, (there were some places where a new object or array was created for convenience reasons, but was not really necessary) - this should slightly reduce the required GC time for cases where a lot of JSX is being processed.
4. JSX Elements props and children are made immutable up-front via `Object.freeze`