### PR TITLE
fix: added `number` as a possible type for input attributes `step` and `value`

### DIFF
--- a/src/jsx/prop-types/input-jsx-props.ts
+++ b/src/jsx/prop-types/input-jsx-props.ts
@@ -55,8 +55,8 @@ export interface InputTagProps {
   required?: AttributeBool;
   size?: string | number;
   src?: string;
-  step?: string;
+  step?: string | number;
   type?: InputType;
-  value?: string;
+  value?: string | number;
   width?: string | number;
 }


### PR DESCRIPTION
Added `number` as a possible type for input attributes `step` and `value`.