### PR TITLE
feat: allow null, undefined, booleans, string and numbers as jsx elements

### DIFF
--- a/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
+++ b/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
@@ -68,6 +68,64 @@ exports[`renderToHTML should correctly generate html from simple jsx 1`] = `
 </div>"
 `;
 
+exports[`renderToHTML should correctly handle component children of type nulls, undefined and other 1`] = `
+"<div>
+  <div>
+    Undef: 
+    <span></span>
+  </div>
+  <div>
+    Null: 
+    <span></span>
+  </div>
+  <div>
+    True: 
+    <span></span>
+  </div>
+  <div>
+    False: 
+    <span></span>
+  </div>
+  <div>
+    Str: 
+    <span>Hello World</span>
+  </div>
+  <div>
+    Num: 
+    <span>1234</span>
+  </div>
+  <div>
+    Arr: 
+    <span>hi423</span>
+  </div>
+</div>"
+`;
+
+exports[`renderToHTML should correctly handle components returning nulls, undefined and other types 1`] = `
+"<div>
+  <div>
+    Undef: 
+  </div>
+  <div>
+    Null: 
+  </div>
+  <div>
+    True: 
+  </div>
+  <div>
+    False: 
+  </div>
+  <div>
+    Str: 
+Hello World
+  </div>
+  <div>
+    Num: 
+1234
+  </div>
+</div>"
+`;
+
 exports[`renderToHTML should correctly parse async components 1`] = `
 "<html>
   <head>

--- a/__tests__/html-parser/render-to-html.test.tsx
+++ b/__tests__/html-parser/render-to-html.test.tsx
@@ -19,11 +19,18 @@ describe("renderToHTML", () => {
   it("should correctly generate html from simple jsx", () => {
     const Component = (props: { title: string }) => {
       return (
-        <div id="container" class={"bordered active"}>
+        <div
+          id="container"
+          class={"bordered active"}
+        >
           <h1>Hello World</h1>
           <h2>{props.title}</h2>
           <button onclick={'console.log("Hello World!")'}>Click me!</button>
-          <input autofocus={true} disabled={false} draggable />
+          <input
+            autofocus={true}
+            disabled={false}
+            draggable
+          />
         </div>
       );
     };
@@ -47,7 +54,10 @@ describe("renderToHTML", () => {
         <html>
           <head>
             <meta charset="utf-8" />
-            <meta http-equiv="x-ua-compatible" content="IE=edge" />
+            <meta
+              http-equiv="x-ua-compatible"
+              content="IE=edge"
+            />
             <title>Page Title</title>
             <meta
               name="viewport"
@@ -126,7 +136,10 @@ describe("renderToHTML", () => {
         <html>
           <head>
             <meta charset="utf-8" />
-            <meta http-equiv="x-ua-compatible" content="IE=edge" />
+            <meta
+              http-equiv="x-ua-compatible"
+              content="IE=edge"
+            />
             <title>Page Title</title>
             <meta
               name="viewport"
@@ -267,7 +280,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -347,7 +363,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -430,7 +449,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -503,7 +525,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -539,7 +564,7 @@ describe("renderToHTML", () => {
           context: ContextDefinition<T>;
           value: T;
         },
-        { ctx }: ComponentApi
+        { ctx }: ComponentApi,
       ) => {
         ctx.set(props.context, props.value);
         return <>{props.children}</>;
@@ -569,7 +594,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -582,7 +610,10 @@ describe("renderToHTML", () => {
                 href="main.css"
               />
             </head>
-            <Provider context={myContext} value={{ title: "Provided title" }}>
+            <Provider
+              context={myContext}
+              value={{ title: "Provided title" }}
+            >
               <body>
                 <Content />
               </body>
@@ -610,7 +641,7 @@ describe("renderToHTML", () => {
           value: T;
           sleep?: boolean;
         }>,
-        { ctx }: ComponentApi
+        { ctx }: ComponentApi,
       ) => {
         if (props.sleep) await sleep(Math.random() * 1000);
         ctx.set(props.context, props.value);
@@ -650,7 +681,10 @@ describe("renderToHTML", () => {
       const html = await renderToHtmlAsync(
         <html>
           <body>
-            <Provider context={store} value={"foo"}>
+            <Provider
+              context={store}
+              value={"foo"}
+            >
               <div>
                 <div>
                   <W1 />
@@ -658,7 +692,7 @@ describe("renderToHTML", () => {
               </div>
             </Provider>
           </body>
-        </html>
+        </html>,
       );
 
       expect(html).toMatchSnapshot();
@@ -678,7 +712,7 @@ describe("renderToHTML", () => {
           value: T;
           sleep?: number;
         }>,
-        { ctx }: ComponentApi
+        { ctx }: ComponentApi,
       ) => {
         if (props.sleep) await sleep(props.sleep);
         ctx.set(props.context, props.value);
@@ -688,31 +722,56 @@ describe("renderToHTML", () => {
       const html = await renderToHtmlAsync(
         <html>
           <body>
-            <Provider context={store} value={"foo"}>
-              <Provider sleep={30} context={store} value={"bar"}>
+            <Provider
+              context={store}
+              value={"foo"}
+            >
+              <Provider
+                sleep={30}
+                context={store}
+                value={"bar"}
+              >
                 <Title />
               </Provider>
               {[
-                <Provider context={store} value={"baz"}>
+                <Provider
+                  context={store}
+                  value={"baz"}
+                >
                   <Title />
                 </Provider>,
-                <Provider sleep={50} context={store} value={"qux"}>
+                <Provider
+                  sleep={50}
+                  context={store}
+                  value={"qux"}
+                >
                   <Title />
                 </Provider>,
-                <Provider sleep={10} context={store} value={"coorg"}>
+                <Provider
+                  sleep={10}
+                  context={store}
+                  value={"coorg"}
+                >
                   <Title />
                 </Provider>,
               ]}
-              <Provider sleep={30} context={store} value={"fred"}>
+              <Provider
+                sleep={30}
+                context={store}
+                value={"fred"}
+              >
                 <Title />
               </Provider>
-              <Provider context={store} value={"thud"}>
+              <Provider
+                context={store}
+                value={"thud"}
+              >
                 <Title />
               </Provider>
               <Title />
             </Provider>
           </body>
-        </html>
+        </html>,
       );
 
       expect(html).toMatchSnapshot();
@@ -728,14 +787,14 @@ describe("renderToHTML", () => {
             props: JSXTE.PropsWithChildren<{
               value: T;
             }>,
-            { ctx }: ComponentApi
+            { ctx }: ComponentApi,
           ) => {
             ctx.set(dctx, props.value);
             return <>{props.children}</>;
           },
           Consumer: (
             props: { render: (value?: T) => JSX.Element },
-            { ctx }: ComponentApi
+            { ctx }: ComponentApi,
           ) => {
             if (ctx.has(dctx)) {
               const value = ctx.get(dctx);
@@ -772,7 +831,12 @@ describe("renderToHTML", () => {
           <MagicalContext.Consumer
             render={(ctxName) => {
               const fullName = `${ctxName ?? ""}${name}`;
-              return <input type="text" name={fullName} />;
+              return (
+                <input
+                  type="text"
+                  name={fullName}
+                />
+              );
             }}
           />
         );
@@ -805,7 +869,10 @@ describe("renderToHTML", () => {
       const Foo: JSXTE.Component<{ id: string }> = (props, { ctx }) => {
         const value = ctx.get(MagicalContext) ?? "no value";
         return (
-          <div id={props.id} class="foo">
+          <div
+            id={props.id}
+            class="foo"
+          >
             {value}
           </div>
         );
@@ -853,7 +920,7 @@ describe("renderToHTML", () => {
       onError(
         error: unknown,
         originalProps: JSXTE.ElementProps,
-        contextMap: ComponentApi
+        contextMap: ComponentApi,
       ): JSX.Element {
         return <h1>Oops. Something went wrong.</h1>;
       }
@@ -873,7 +940,10 @@ describe("renderToHTML", () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="x-ua-compatible" content="IE=edge" />
+              <meta
+                http-equiv="x-ua-compatible"
+                content="IE=edge"
+              />
               <title>Page Title</title>
               <meta
                 name="viewport"
@@ -1134,5 +1204,87 @@ describe("renderToHTML", () => {
         expect(html).toMatchSnapshot();
       });
     });
+  });
+
+  it("should correctly handle components returning nulls, undefined and other types", () => {
+    const RetUndef = () => undefined;
+    const RetNull = () => null;
+    const RetTrue = () => true;
+    const RetFalse = () => false;
+    const RetStr = () => "Hello World";
+    const RetNum = () => 1234;
+
+    const Main = () => {
+      return (
+        <div>
+          <div>
+            Undef: <RetUndef />
+          </div>
+          <div>
+            Null: <RetNull />
+          </div>
+          <div>
+            True: <RetTrue />
+          </div>
+          <div>
+            False: <RetFalse />
+          </div>
+          <div>
+            Str: <RetStr />
+          </div>
+          <div>
+            Num: <RetNum />
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToHtml(<Main />);
+
+    expect(html).toMatchSnapshot();
+  });
+
+  it("should correctly handle component children of type nulls, undefined and other", () => {
+    const RetUndef = () => <span>{undefined}</span>;
+    const RetNull = () => <span>{null}</span>;
+    const RetTrue = () => <span>{true}</span>;
+    const RetFalse = () => <span>{false}</span>;
+    const RetStr = () => <span>{"Hello World"}</span>;
+    const RetNum = () => <span>{1234}</span>;
+    const RetArr = () => (
+      <span>{[undefined, null, true, false, "hi", 423]}</span>
+    );
+
+    const Main = () => {
+      return (
+        <div>
+          <div>
+            Undef: <RetUndef />
+          </div>
+          <div>
+            Null: <RetNull />
+          </div>
+          <div>
+            True: <RetTrue />
+          </div>
+          <div>
+            False: <RetFalse />
+          </div>
+          <div>
+            Str: <RetStr />
+          </div>
+          <div>
+            Num: <RetNum />
+          </div>
+          <div>
+            Arr: <RetArr />
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToHtml(<Main />);
+
+    expect(html).toMatchSnapshot();
   });
 });

--- a/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
+++ b/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
@@ -397,6 +397,163 @@ Object {
 }
 `;
 
+exports[`renderToJson should correctly handle component children of type nulls, undefined and other 1`] = `
+Object {
+  "attributes": Array [],
+  "children": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Undef: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Null: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "True: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "False: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Str: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [
+            "Hello World",
+          ],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Num: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [
+            "1234",
+          ],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Arr: ",
+        Object {
+          "attributes": Array [],
+          "children": Array [
+            "hi",
+            "423",
+          ],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+  ],
+  "element": "div",
+}
+`;
+
+exports[`renderToJson should correctly handle components returning nulls, undefined and other types 1`] = `
+Object {
+  "attributes": Array [],
+  "children": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Undef: ",
+        "",
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Null: ",
+        "",
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "True: ",
+        "",
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "False: ",
+        "",
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Str: ",
+        "Hello World",
+      ],
+      "element": "div",
+    },
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        "Num: ",
+        "1234",
+      ],
+      "element": "div",
+    },
+  ],
+  "element": "div",
+}
+`;
+
 exports[`renderToJson should correctly parse async components 1`] = `
 Object {
   "attributes": Array [],

--- a/__tests__/json-renderer/render-to-json.test.tsx
+++ b/__tests__/json-renderer/render-to-json.test.tsx
@@ -1202,4 +1202,86 @@ describe("renderToJson", () => {
       });
     });
   });
+
+  it("should correctly handle components returning nulls, undefined and other types", () => {
+    const RetUndef = () => undefined;
+    const RetNull = () => null;
+    const RetTrue = () => true;
+    const RetFalse = () => false;
+    const RetStr = () => "Hello World";
+    const RetNum = () => 1234;
+
+    const Main = () => {
+      return (
+        <div>
+          <div>
+            Undef: <RetUndef />
+          </div>
+          <div>
+            Null: <RetNull />
+          </div>
+          <div>
+            True: <RetTrue />
+          </div>
+          <div>
+            False: <RetFalse />
+          </div>
+          <div>
+            Str: <RetStr />
+          </div>
+          <div>
+            Num: <RetNum />
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToJson(<Main />);
+
+    expect(html).toMatchSnapshot();
+  });
+
+  it("should correctly handle component children of type nulls, undefined and other", () => {
+    const RetUndef = () => <span>{undefined}</span>;
+    const RetNull = () => <span>{null}</span>;
+    const RetTrue = () => <span>{true}</span>;
+    const RetFalse = () => <span>{false}</span>;
+    const RetStr = () => <span>{"Hello World"}</span>;
+    const RetNum = () => <span>{1234}</span>;
+    const RetArr = () => (
+      <span>{[undefined, null, true, false, "hi", 423]}</span>
+    );
+
+    const Main = () => {
+      return (
+        <div>
+          <div>
+            Undef: <RetUndef />
+          </div>
+          <div>
+            Null: <RetNull />
+          </div>
+          <div>
+            True: <RetTrue />
+          </div>
+          <div>
+            False: <RetFalse />
+          </div>
+          <div>
+            Str: <RetStr />
+          </div>
+          <div>
+            Num: <RetNum />
+          </div>
+          <div>
+            Arr: <RetArr />
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToJson(<Main />);
+
+    expect(html).toMatchSnapshot();
+  });
 });

--- a/src/html-parser/jsx-elem-to-html.ts
+++ b/src/html-parser/jsx-elem-to-html.ts
@@ -5,9 +5,12 @@ import { SELF_CLOSING_TAG_LIST } from "../utilities/self-closing-tag-list";
 import { mapAttributesToHtmlTagString } from "./attribute-to-html-tag-string";
 import { getHTMLStruct } from "./get-html-struct";
 
-const isSyncElem = (e: JSX.Element): e is JSXTE.SyncElement => true;
+function assertSyncElem(
+  e: JSXTE.TagElement | JSXTE.TextNodeElement | JSX.AsyncElement,
+): asserts e is JSXTE.SyncElement {}
+
 const isTextNode = (e: JSX.Element): e is JSXTE.TextNodeElement =>
-  "type" in e && e.type === "textNode";
+  typeof e === "object" && e != null && "type" in e && e.type === "textNode";
 
 export type RendererInternalOptions = {
   indent?: number;
@@ -20,6 +23,22 @@ export const jsxElemToHtmlSync = (
   _componentApi?: ComponentApi,
   options?: RendererInternalOptions,
 ): string => {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (typeof element) {
+    case "string":
+      return element;
+    case "bigint":
+    case "number":
+      return String(element);
+    case "boolean":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return "";
+  }
+
+  if (element === null) return "";
+
   const attributeMap = options?.attributeMap ?? {};
   const currentIndent = options?.currentIndent ?? 0;
   const indent = options?.indent ?? 2;
@@ -28,7 +47,7 @@ export const jsxElemToHtmlSync = (
     ? ComponentApi.clone(_componentApi)
     : ComponentApi.create(options);
 
-  if (!isSyncElem(element)) throw new Error("");
+  assertSyncElem(element);
 
   if (element.type === "textNode") {
     const indentPadding = " ".repeat(currentIndent);
@@ -163,12 +182,28 @@ export const jsxElemToHtmlAsync = async (
   _componentApi?: ComponentApi,
   options?: RendererInternalOptions,
 ): Promise<string> => {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (typeof element) {
+    case "string":
+      return element;
+    case "bigint":
+    case "number":
+      return String(element);
+    case "boolean":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return "";
+  }
+
+  if (element === null) return "";
+
   const { attributeMap = {}, currentIndent = 0, indent = 2 } = options ?? {};
   const componentApi = _componentApi
     ? ComponentApi.clone(_componentApi)
     : ComponentApi.create(options);
 
-  if (!isSyncElem(element)) throw new Error("");
+  assertSyncElem(element);
 
   if (element.type === "textNode") {
     const indentPadding = " ".repeat(currentIndent);

--- a/src/json-renderer/jsx-elem-to-json.ts
+++ b/src/json-renderer/jsx-elem-to-json.ts
@@ -2,7 +2,9 @@ import { ComponentApi } from "../component-api/component-api";
 import { ErrorBoundary } from "../error-boundary/error-boundary";
 import { getHTMLStruct } from "../html-parser/get-html-struct";
 
-const isSyncElem = (e: JSX.Element): e is JSXTE.SyncElement => true;
+function assertSyncElem(
+  e: JSXTE.TagElement | JSXTE.TextNodeElement | JSX.AsyncElement,
+): asserts e is JSXTE.SyncElement {}
 
 export type JsonRendererInternalOptions = {
   attributeMap?: Record<string, string>;
@@ -19,13 +21,29 @@ export const jsxElemToJsonSync = (
   _componentApi?: ComponentApi,
   options?: JsonRendererInternalOptions,
 ): JsxteJson | string => {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (typeof element) {
+    case "string":
+      return element;
+    case "bigint":
+    case "number":
+      return String(element);
+    case "boolean":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return "";
+  }
+
+  if (element === null) return "";
+
   const attributeMap = options?.attributeMap ?? {};
 
   const componentApi = _componentApi
     ? ComponentApi.clone(_componentApi)
     : ComponentApi.create(options);
 
-  if (!isSyncElem(element)) throw new Error("");
+  assertSyncElem(element);
 
   if (element.type === "textNode") {
     return element.text;
@@ -107,13 +125,29 @@ export const jsxElemToJsonAsync = async (
   _componentApi?: ComponentApi,
   options?: JsonRendererInternalOptions,
 ): Promise<JsxteJson | string> => {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (typeof element) {
+    case "string":
+      return element;
+    case "bigint":
+    case "number":
+      return String(element);
+    case "boolean":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return "";
+  }
+
+  if (element === null) return "";
+
   const attributeMap = options?.attributeMap ?? {};
 
   const componentApi = _componentApi
     ? ComponentApi.clone(_componentApi)
     : ComponentApi.create(options);
 
-  if (!isSyncElem(element)) throw new Error("");
+  assertSyncElem(element);
 
   if (element.type === "textNode") {
     return element.text;

--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -27,9 +27,7 @@ declare global {
     type TagElement = {
       type: "tag";
       tag:
-        | string
-        | ((props: ElementProps, contextMap: ComponentApi) => Element)
-        | ((props: ElementProps, contextMap: ComponentApi) => Promise<Element>)
+        | ((props: ElementProps, contextMap: ComponentApi) => JSX.Element)
         | ErrorBoundaryElement;
       props: ElementProps;
     };

--- a/src/jsx/jsx.types.ts
+++ b/src/jsx/jsx.types.ts
@@ -49,8 +49,23 @@ import type { HTMLProps } from "./base-html-tag-props";
 
 declare global {
   namespace JSX {
-    type AsyncElement = Promise<JSXTE.TagElement | JSXTE.TextNodeElement>;
-    type SyncElement = JSXTE.TagElement | JSXTE.TextNodeElement;
+    type AsyncElement = Promise<
+      | JSXTE.TagElement
+      | JSXTE.TextNodeElement
+      | null
+      | undefined
+      | boolean
+      | string
+      | number
+    >;
+    type SyncElement =
+      | JSXTE.TagElement
+      | JSXTE.TextNodeElement
+      | null
+      | undefined
+      | boolean
+      | string
+      | number;
 
     type Element = SyncElement | AsyncElement;
 


### PR DESCRIPTION
It is now possible to return other things from function components than elements created via `createElement` or JSX syntax. Anything that is not an object, string or number will be treated as if `<></>` was returned, returned strings and numbers will be treated as `<>{value}</>`, objects are expected to be elements created via `createElement` or JSX syntax (no change here).

This means that the following components are now possible:
```tsx
function MyComponent() {
  return !!condition && <div>...</div>;
} 

function MyComponent() {
  return "Hello";
} 

function MyComponent() {
  return 2023;
} 

// ok
renderToHtml(
  <div>
    <MyComponent />
  </div>
)
```