### PR TITLE
Add view-transition as allowed name for meta-tag.

### DIFF
--- a/src/jsx/prop-types/meta-jsx-props.ts
+++ b/src/jsx/prop-types/meta-jsx-props.ts
@@ -15,7 +15,8 @@ declare global {
         | "description"
         | "generator"
         | "keywords"
-        | "viewport";
+        | "viewport"
+        | "view-transition";
     }
   }
 }


### PR DESCRIPTION
It's quite new, but helps a lot to showcase MPAs with smooth transitions.

https://daverupert.com/2023/05/getting-started-view-transitions/

Current workaround is to use a template literal:

{`<meta name="view-transition" content="same-origin" />`}