### PR TITLE
feat: added jsx-dev-runtime to the exported paths

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,5 +17,7 @@ yarn.lock
 package-lock.json
 jsx-runtime.d.ts
 jsx-runtime.js
+jsx-dev-runtime.d.ts
+jsx-dev-runtime.js
 docs
 scripts

--- a/jsx-dev-runtime.d.ts
+++ b/jsx-dev-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/types/jsx-dev-runtime";

--- a/jsx-dev-runtime.js
+++ b/jsx-dev-runtime.js
@@ -21,10 +21,10 @@ var __reExport = (target, mod, secondTarget) => (
 var __toCommonJS = (mod) =>
   __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-var jsx_runtime_exports = {};
-module.exports = __toCommonJS(jsx_runtime_exports);
+var jsx_dev_runtime_exports = {};
+module.exports = __toCommonJS(jsx_dev_runtime_exports);
 __reExport(
-  jsx_runtime_exports,
-  require("./dist/legacy/jsx-runtime"),
+  jsx_dev_runtime_exports,
+  require("./dist/legacy/jsx-dev-runtime"),
   module.exports,
 );

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "types": "./dist/types/jsx-runtime.d.ts",
       "import": "./dist/esm/jsx-runtime.mjs",
       "require": "./dist/cjs/jsx-runtime.cjs"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./dist/types/jsx-dev-runtime.d.ts",
+      "import": "./dist/esm/jsx-dev-runtime.mjs",
+      "require": "./dist/cjs/jsx-dev-runtime.cjs"
     }
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./json-renderer/render-to-json";
 export { renderToStringTemplateTag } from "./string-template-renderer/render-to-string-template-tag";
 export { memo } from "./utilities/memo";
+export { createElement } from "./jsx/jsx-runtime";
 
 export type {
   ContextDefinition,

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from "./jsx/jsx-dev-runtime";

--- a/src/jsx/jsx-dev-runtime.ts
+++ b/src/jsx/jsx-dev-runtime.ts
@@ -1,0 +1,11 @@
+import {
+  Fragment,
+  _Fragment,
+  _jsx,
+  _jsxs,
+  createElement,
+  jsx,
+  jsxs,
+} from "./jsx-runtime";
+
+export { Fragment, _Fragment, _jsx, _jsxs, createElement, jsx, jsxs };


### PR DESCRIPTION
Added a new export under `jsxte/jsx-dev-runtime`, atm it exports the exact same functions as the `jsxte/jsx-runtime`. This should prevent build errors when the "jsx" build option is set to `jsx-reactdev`. This change specifically targets Bun, which always assumes this settings unless NODE_ENV is set to `production`.