### PR TITLE
feat: added toHtmlTag symbol

### DIFF
--- a/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
+++ b/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
@@ -170,6 +170,14 @@ exports[`renderToHTML should correctly render jsx with arrays in between element
 </div>"
 `;
 
+exports[`renderToHTML should correctly render objects implementing toHtmlTag symbol interface 1`] = `
+"<div>
+  <div>
+    <span>John Doe</span>
+  </div>
+</div>"
+`;
+
 exports[`renderToHTML should properly handle context data Provider and Consumer 1`] = `
 "<html>
   <body>

--- a/__tests__/html-parser/render-to-html.test.tsx
+++ b/__tests__/html-parser/render-to-html.test.tsx
@@ -1287,4 +1287,36 @@ describe("renderToHTML", () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  it("should correctly render objects implementing toHtmlTag symbol interface", () => {
+    class User {
+      constructor(
+        public firstName: string,
+        public lastName: string,
+        public age: number,
+        public email: string,
+        public friends: User[],
+      ) {}
+
+      [Symbol.toHtmlTag]() {
+        return `${this.firstName} ${this.lastName}`;
+      }
+    }
+
+    const user = new User("John", "Doe", 30, "johndoe@gmail.com", []);
+
+    const App = () => {
+      return (
+        <div>
+          <div>
+            <span>{user}</span>
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToHtml(<App />);
+
+    expect(html).toMatchSnapshot();
+  });
 });

--- a/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
+++ b/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
@@ -789,6 +789,28 @@ Object {
 }
 `;
 
+exports[`renderToJson should correctly render objects implementing toHtmlTag symbol interface 1`] = `
+Object {
+  "attributes": Array [],
+  "children": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        Object {
+          "attributes": Array [],
+          "children": Array [
+            "John Doe",
+          ],
+          "element": "span",
+        },
+      ],
+      "element": "div",
+    },
+  ],
+  "element": "div",
+}
+`;
+
 exports[`renderToJson should properly handle context data Provider and Consumer 1`] = `
 Object {
   "attributes": Array [],

--- a/__tests__/json-renderer/render-to-json.test.tsx
+++ b/__tests__/json-renderer/render-to-json.test.tsx
@@ -1284,4 +1284,36 @@ describe("renderToJson", () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  it("should correctly render objects implementing toHtmlTag symbol interface", () => {
+    class User {
+      constructor(
+        public firstName: string,
+        public lastName: string,
+        public age: number,
+        public email: string,
+        public friends: User[],
+      ) {}
+
+      [Symbol.toHtmlTag]() {
+        return `${this.firstName} ${this.lastName}`;
+      }
+    }
+
+    const user = new User("John", "Doe", 30, "johndoe@gmail.com", []);
+
+    const App = () => {
+      return (
+        <div>
+          <div>
+            <span>{user}</span>
+          </div>
+        </div>
+      );
+    };
+
+    const html = renderToJson(<App />);
+
+    expect(html).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Added a special symbol that allows to determine how an object should be stringified when used as a child of a JSX element.

### Example

```tsx
class User {
  constructor(
    public id: string,
    public username: string,
    public email: string,
  ) {}

  [Symbol.toHtmlTag]() {
    return `User: ${this.username}`;
  }
}

const user = new User("001", "Johny", "johny0169@gmail.com");

renderToHtml(<div>{user}</div>);
```
The above will produce this result:
```html
<div>User: Johny</div>
```