### PR TITLE
feat: added component traces to errors

### DIFF
--- a/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
+++ b/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
@@ -40,6 +40,77 @@ exports[`renderToHTML ErrorBoundary should render the fallback if the direct chi
 </html>"
 `;
 
+exports[`renderToHTML errors error throw should contain information on which place in the tree the error occurred scenario 1 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<html>
+<body>
+<div>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToHTML errors error throw should contain information on which place in the tree the error occurred scenario 2 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<html>
+<body>
+<div>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToHTML errors error throw should contain information on which place in the tree the error occurred scenario 3 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<FailsEventually>
+<span>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToHTML errors error throw should contain information on which place in the tree the error occurred scenario 4 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<FailsEventually>
+<span>
+<Failing>
+
+Rendering has failed due to an error: I'm failing async]
+`;
+
+exports[`renderToHTML errors error throw should contain information on which place in the tree the error occurred scenario 5 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<>
+<FailsEventually>
+<span>
+<>
+<Failing>
+
+Rendering has failed due to an error: I'm failing async]
+`;
+
 exports[`renderToHTML should correctly generate html from component base jsx structure 1`] = `
 "<html>
   <head>

--- a/__tests__/html-parser/render-to-html.test.tsx
+++ b/__tests__/html-parser/render-to-html.test.tsx
@@ -1319,4 +1319,182 @@ describe("renderToHTML", () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  describe("errors", () => {
+    describe("error throw should contain information on which place in the tree the error occurred", () => {
+      const Failing = () => {
+        throw new Error("I'm failing");
+      };
+
+      it("scenario 1", () => {
+        expect.assertions(1);
+        try {
+          renderToHtml(
+            <html>
+              <body>
+                <div>
+                  <Failing />
+                </div>
+              </body>
+            </html>,
+          );
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 2", () => {
+        expect.assertions(1);
+        try {
+          const Main = () => {
+            return (
+              <html>
+                <body>
+                  <div>
+                    <Failing />
+                  </div>
+                </body>
+              </html>
+            );
+          };
+          renderToHtml(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 3", () => {
+        expect.assertions(1);
+        try {
+          const Html = (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const FailsEventually = () => {
+            return (
+              <span>
+                <Failing></Failing>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <FailsEventually />
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          renderToHtml(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 4", async () => {
+        expect.assertions(1);
+        try {
+          const Html = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const Failing = async () => {
+            throw new Error("I'm failing async");
+          };
+
+          const FailsEventually = async () => {
+            return (
+              <span>
+                <Failing></Failing>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <FailsEventually />
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          await renderToHtmlAsync(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 5", async () => {
+        expect.assertions(1);
+        try {
+          const Html = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const Failing = async () => {
+            throw new Error("I'm failing async");
+          };
+
+          const FailsEventually = async () => {
+            return (
+              <span>
+                <>
+                  <Failing></Failing>
+                  {"lol"}
+                </>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <>
+                      <FailsEventually />
+                    </>
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          await renderToHtmlAsync(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+    });
+  });
 });

--- a/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
+++ b/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
@@ -201,6 +201,77 @@ Object {
 }
 `;
 
+exports[`renderToJson errors error throw should contain information on which place in the tree the error occurred scenario 1 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<html>
+<body>
+<div>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToJson errors error throw should contain information on which place in the tree the error occurred scenario 2 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<html>
+<body>
+<div>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToJson errors error throw should contain information on which place in the tree the error occurred scenario 3 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<FailsEventually>
+<span>
+<Failing>
+
+Rendering has failed due to an error: I'm failing]
+`;
+
+exports[`renderToJson errors error throw should contain information on which place in the tree the error occurred scenario 4 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<FailsEventually>
+<span>
+<Failing>
+
+Rendering has failed due to an error: I'm failing async]
+`;
+
+exports[`renderToJson errors error throw should contain information on which place in the tree the error occurred scenario 5 1`] = `
+[JsxteRenderError: The below error has occurred in:
+<Main>
+<Html>
+<html>
+<body>
+<div>
+<Wrapper>
+<div>
+<>
+<FailsEventually>
+<span>
+<>
+<Failing>
+
+Rendering has failed due to an error: I'm failing async]
+`;
+
 exports[`renderToJson should correctly generate html from component base jsx structure 1`] = `
 Object {
   "attributes": Array [],

--- a/__tests__/json-renderer/render-to-json.test.tsx
+++ b/__tests__/json-renderer/render-to-json.test.tsx
@@ -1316,4 +1316,182 @@ describe("renderToJson", () => {
 
     expect(html).toMatchSnapshot();
   });
+
+  describe("errors", () => {
+    describe("error throw should contain information on which place in the tree the error occurred", () => {
+      const Failing = () => {
+        throw new Error("I'm failing");
+      };
+
+      it("scenario 1", () => {
+        expect.assertions(1);
+        try {
+          renderToJson(
+            <html>
+              <body>
+                <div>
+                  <Failing />
+                </div>
+              </body>
+            </html>,
+          );
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 2", () => {
+        expect.assertions(1);
+        try {
+          const Main = () => {
+            return (
+              <html>
+                <body>
+                  <div>
+                    <Failing />
+                  </div>
+                </body>
+              </html>
+            );
+          };
+          renderToJson(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 3", () => {
+        expect.assertions(1);
+        try {
+          const Html = (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const FailsEventually = () => {
+            return (
+              <span>
+                <Failing></Failing>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <FailsEventually />
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          renderToJson(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 4", async () => {
+        expect.assertions(1);
+        try {
+          const Html = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const Failing = async () => {
+            throw new Error("I'm failing async");
+          };
+
+          const FailsEventually = async () => {
+            return (
+              <span>
+                <Failing></Failing>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <FailsEventually />
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          await renderToJsonAsync(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+
+      it("scenario 5", async () => {
+        expect.assertions(1);
+        try {
+          const Html = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return (
+              <html>
+                <body>{props.children}</body>
+              </html>
+            );
+          };
+
+          const Wrapper = async (props: JSXTE.PropsWithChildren<{}>) => {
+            return <div>{props.children}</div>;
+          };
+
+          const Failing = async () => {
+            throw new Error("I'm failing async");
+          };
+
+          const FailsEventually = async () => {
+            return (
+              <span>
+                <>
+                  <Failing></Failing>
+                  {"lol"}
+                </>
+              </span>
+            );
+          };
+
+          const Main = () => {
+            return (
+              <Html>
+                <div>
+                  <Wrapper>
+                    <>
+                      <FailsEventually />
+                    </>
+                  </Wrapper>
+                </div>
+              </Html>
+            );
+          };
+          await renderToJsonAsync(<Main />);
+        } catch (err) {
+          expect(err).toMatchSnapshot();
+        }
+      });
+    });
+  });
 });

--- a/src/html-renderer/render-to-html.ts
+++ b/src/html-renderer/render-to-html.ts
@@ -6,24 +6,24 @@ type HtmlRenderOptions = {
 };
 
 /**
- * Renders the provided JSX component to pure html. This function
- * is synchronous and will not render components that are asynchronous.
+ * Renders the provided JSX component to pure html. This function is synchronous
+ * and will not render components that are asynchronous.
  */
 export const renderToHtml = (
   component: JSX.Element,
-  options?: HtmlRenderOptions
+  options?: HtmlRenderOptions,
 ) => {
   return jsxElemToHtmlSync(component, undefined, options);
 };
 
 /**
- * Renders the provided JSX component to pure html. This function
- * is asynchronous, it allows to use asynchronous components
- * withing the provided component structure.
+ * Renders the provided JSX component to pure html. This function is
+ * asynchronous, it allows to use asynchronous components withing the provided
+ * component structure.
  */
 export const renderToHtmlAsync = async (
   component: JSX.Element | Promise<JSX.Element>,
-  options?: HtmlRenderOptions
+  options?: HtmlRenderOptions,
 ) => {
   return await jsxElemToHtmlAsync(await component, undefined, options);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 export { renderToStringTemplateTag } from "./string-template-renderer/render-to-string-template-tag";
 export { memo } from "./utilities/memo";
 export { createElement } from "./jsx/jsx-runtime";
+export { JsxteRenderError } from "./jsxte-render-error";
 
 export type {
   ContextDefinition,

--- a/src/jsxte-render-error.ts
+++ b/src/jsxte-render-error.ts
@@ -1,0 +1,50 @@
+const mapReverse = <T, U>(arr: T[], fn: (item: T) => U): U[] => {
+  const result: U[] = [];
+  for (let i = arr.length - 1; i >= 0; i--) {
+    result.push(fn(arr[i]!));
+  }
+  return result;
+};
+
+export class JsxteRenderError extends Error {
+  static is(err: any): err is JsxteRenderError {
+    return err instanceof JsxteRenderError;
+  }
+
+  private baseMessage: string = "";
+  private parentTags: string[] = [];
+  public declare cause: any;
+
+  constructor(message: string, insideTag?: string, causedBy?: any) {
+    // @ts-expect-error
+    super(message, { cause: causedBy });
+    this.name = "JsxteRenderError";
+    this.baseMessage = message;
+
+    if (insideTag) {
+      this.parentTags.push(insideTag);
+    }
+
+    if (this.cause == null) {
+      Object.defineProperty(this, "cause", {
+        value: causedBy,
+        enumerable: true,
+        writable: true,
+      });
+    }
+
+    this.message = this.generateMessage();
+  }
+
+  pushParent(tag: string) {
+    this.parentTags.push(tag);
+    this.message = this.generateMessage();
+  }
+
+  generateMessage() {
+    return `The below error has occurred in:\n${mapReverse(
+      this.parentTags,
+      (tag) => `<${tag}>`,
+    ).join("\n")}\n\n${this.baseMessage}`;
+  }
+}

--- a/src/utilities/get-component-name.ts
+++ b/src/utilities/get-component-name.ts
@@ -1,0 +1,11 @@
+export const getComponentName = (component: Function) => {
+  if ("displayName" in component && typeof component.displayName === "string") {
+    return component.displayName;
+  }
+
+  if ("name" in component && typeof component.name === "string") {
+    return component.name;
+  }
+
+  return "AnonymousComponent";
+};

--- a/src/utilities/get-err-message.ts
+++ b/src/utilities/get-err-message.ts
@@ -1,0 +1,11 @@
+export const getErrorMessage = (err: any) => {
+  if (err instanceof Error) {
+    return err.message;
+  }
+
+  if (typeof err === "string") {
+    return err;
+  }
+
+  return String(err);
+};


### PR DESCRIPTION
Added traces to errors thrown by the renderer to allow easier debugging. This is achieved by catching any errors during rendering and when that happens, throwing custom errors instead. Original errors can still be accessed via the `.cause` property. 

### Example

If an error occurs in a component called `MyComponent` you might see an error like this:
```
JsxteRendererError: The below error has occurred in:
<App>
<html>
<body>
<Layout>
<div>
<MyComponent>

Rendering has failed due to an error: <Actual error message>
```

#### Accessing the original error

```tsx
try {
  const html = renderToHtml(<App />);
} catch (error) {
  error; // -> JsxteRendererError
  error.cause; // -> original error
}
```