### PR TITLE
fix: meta's name and link's rel attribute types prevented valid values

### DIFF
--- a/src/jsx/prop-types/link-jsx-props.ts
+++ b/src/jsx/prop-types/link-jsx-props.ts
@@ -26,23 +26,7 @@ declare global {
       media?: string;
       prefetch?: string;
       referrerpolicy?: RefererPolicy;
-      rel?:
-        | "alternate"
-        | "author"
-        | "canonical"
-        | "dns-prefetch"
-        | "help"
-        | "icon"
-        | "license"
-        | "next"
-        | "pingback"
-        | "preconnect"
-        | "prefetch"
-        | "preload"
-        | "prerender"
-        | "prev"
-        | "search"
-        | "stylesheet";
+      rel?: string;
       sizes?: string;
       title?: string;
       type?: string;

--- a/src/jsx/prop-types/meta-jsx-props.ts
+++ b/src/jsx/prop-types/meta-jsx-props.ts
@@ -9,14 +9,7 @@ declare global {
         | "refresh";
       charset?: string;
       content?: string;
-      name?:
-        | "application-name"
-        | "author"
-        | "description"
-        | "generator"
-        | "keywords"
-        | "viewport"
-        | "view-transition";
+      name?: string;
     }
   }
 }


### PR DESCRIPTION
Type for the `<meta>`'s `name` attribute was preventing valid values from being used, same for the `<link>`'s `rel` attribute. These attributes will now allow any string to be used.

resolves #249, resolves #248