### PR TITLE
fix: incorrect function name exported from jsx-dev-runtime

### DIFF
--- a/src/jsx/jsx-dev-runtime.ts
+++ b/src/jsx/jsx-dev-runtime.ts
@@ -8,4 +8,14 @@ import {
   jsxs,
 } from "./jsx-runtime";
 
-export { Fragment, _Fragment, _jsx, _jsxs, createElement, jsx, jsxs };
+export {
+  Fragment,
+  _Fragment,
+  _jsx,
+  _jsxs,
+  createElement,
+  jsx,
+  jsxs,
+  jsx as jsxDEV,
+  jsxs as jsxsDEV,
+};


### PR DESCRIPTION
The `jsx-dev-runtime` export is supposed to provide a named exported function under the name `jsxDEV`, that however was not the case, as it was only exporting functions that were named identically to those from `jsx-runtime`.