### PR TITLE
feat: removed fragments from the render error's component traces

### DIFF
--- a/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
+++ b/__tests__/html-parser/__snapshots__/render-to-html.test.tsx.snap
@@ -102,10 +102,8 @@ exports[`renderToHTML errors error throw should contain information on which pla
 <div>
 <Wrapper>
 <div>
-<>
 <FailsEventually>
 <span>
-<>
 <Failing>
 
 Rendering has failed due to an error: I'm failing async]

--- a/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
+++ b/__tests__/json-renderer/__snapshots__/render-to-json.test.tsx.snap
@@ -263,10 +263,8 @@ exports[`renderToJson errors error throw should contain information on which pla
 <div>
 <Wrapper>
 <div>
-<>
 <FailsEventually>
 <span>
-<>
 <Failing>
 
 Rendering has failed due to an error: I'm failing async]

--- a/src/html-renderer/render-to-html.ts
+++ b/src/html-renderer/render-to-html.ts
@@ -1,3 +1,4 @@
+import { JsxteRenderError } from "../jsxte-render-error";
 import { jsxElemToHtmlAsync, jsxElemToHtmlSync } from "./jsx-elem-to-html";
 
 type HtmlRenderOptions = {
@@ -13,7 +14,14 @@ export const renderToHtml = (
   component: JSX.Element,
   options?: HtmlRenderOptions,
 ) => {
-  return jsxElemToHtmlSync(component, undefined, options);
+  try {
+    return jsxElemToHtmlSync(component, undefined, options);
+  } catch (err) {
+    if (JsxteRenderError.is(err)) {
+      err.regenerateMessage();
+    }
+    throw err;
+  }
 };
 
 /**
@@ -25,5 +33,12 @@ export const renderToHtmlAsync = async (
   component: JSX.Element | Promise<JSX.Element>,
   options?: HtmlRenderOptions,
 ) => {
-  return await jsxElemToHtmlAsync(await component, undefined, options);
+  try {
+    return await jsxElemToHtmlAsync(await component, undefined, options);
+  } catch (err) {
+    if (JsxteRenderError.is(err)) {
+      err.regenerateMessage();
+    }
+    throw err;
+  }
 };

--- a/src/json-renderer/render-to-json.ts
+++ b/src/json-renderer/render-to-json.ts
@@ -1,3 +1,4 @@
+import { JsxteRenderError } from "../jsxte-render-error";
 import { jsxElemToJsonAsync, jsxElemToJsonSync } from "./jsx-elem-to-json";
 
 type HtmlRenderOptions = {
@@ -12,16 +13,30 @@ export const renderToJson = (
   component: JSX.Element,
   options?: HtmlRenderOptions,
 ) => {
-  return jsxElemToJsonSync(component, undefined, options);
+  try {
+    return jsxElemToJsonSync(component, undefined, options);
+  } catch (err) {
+    if (JsxteRenderError.is(err)) {
+      err.regenerateMessage();
+    }
+    throw err;
+  }
 };
 
 /**
  * Renders the provided JSX component to a JSON structure. This function is
  * synchronous and will not render components that are asynchronous.
  */
-export const renderToJsonAsync = (
+export const renderToJsonAsync = async (
   component: JSX.Element,
   options?: HtmlRenderOptions,
 ) => {
-  return jsxElemToJsonAsync(component, undefined, options);
+  try {
+    return await jsxElemToJsonAsync(component, undefined, options);
+  } catch (err) {
+    if (JsxteRenderError.is(err)) {
+      err.regenerateMessage();
+    }
+    throw err;
+  }
 };

--- a/src/jsxte-render-error.ts
+++ b/src/jsxte-render-error.ts
@@ -32,18 +32,21 @@ export class JsxteRenderError extends Error {
         writable: true,
       });
     }
-
-    this.message = this.generateMessage();
   }
 
+  /**
+   * @internal
+   */
   pushParent(tag: string) {
     this.parentTags.push(tag);
-    this.message = this.generateMessage();
   }
 
-  generateMessage() {
-    return `The below error has occurred in:\n${mapReverse(
-      this.parentTags,
+  /**
+   * @internal
+   */
+  regenerateMessage() {
+    this.message = `The below error has occurred in:\n${mapReverse(
+      this.parentTags.filter((t) => t !== ""),
       (tag) => `<${tag}>`,
     ).join("\n")}\n\n${this.baseMessage}`;
   }


### PR DESCRIPTION
In the previous version a new feature was added that added component traces to the rendering errors. As a result you would see error messages that looked like this:

```
JsxteRendererError: The below error has occurred in:
  <html>
  <body>
  <div>
  <>
  <span>
  
  Rendering has failed due to an error...
```

These messages have been updated to omit fragments from these traces, i.e. `<>` tags will no longer appear in the error message traces.