### PR TITLE
fix: missing meta properties and button disabled prop type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false,
-    "source.fixAll.eslint": true
+    "source.organizeImports": "never",
+    "source.fixAll.eslint": "explicit"
   },
   "cSpell.words": ["jsxs", "JSXTE"],
   "json.schemas": [

--- a/src/jsx/prop-types/button-jsx-props.ts
+++ b/src/jsx/prop-types/button-jsx-props.ts
@@ -4,7 +4,7 @@ declare global {
   namespace JSXTE {
     interface ButtonTagProps {
       autofocus?: AttributeBool;
-      disabled?: string;
+      disabled?: AttributeBool;
       form?: string;
       formaction?: string;
       formenctype?: string;

--- a/src/jsx/prop-types/meta-jsx-props.ts
+++ b/src/jsx/prop-types/meta-jsx-props.ts
@@ -10,6 +10,8 @@ declare global {
       charset?: string;
       content?: string;
       name?: string;
+      property?: string;
+      media?: string;
     }
   }
 }


### PR DESCRIPTION
Added the missing `<meta>` tag properties to the prop type definitions (`property` and `media`).

Fixed the typing on the `<button>` disabled property.

closes #259 
closes #260 