### PR TITLE
feat: add dom render methods to component api and allow for option overrides

### DIFF
--- a/src/component-api/component-api.ts
+++ b/src/component-api/component-api.ts
@@ -1,3 +1,5 @@
+import type { DomRenderOptions } from "../dom-renderer/dom-renderer";
+import { DomRenderer } from "../dom-renderer/dom-renderer";
 import { jsxElemToHtmlAsync } from "../html-renderer/jsx-elem-to-html-async";
 import { jsxElemToHtmlSync } from "../html-renderer/jsx-elem-to-html-sync";
 import type { HtmlRenderOptions } from "../html-renderer/render-to-html";
@@ -5,6 +7,7 @@ import {
   jsxElemToJsonAsync,
   jsxElemToJsonSync,
 } from "../json-renderer/jsx-elem-to-json";
+import type { JsonRenderOptions } from "../json-renderer/render-to-json";
 import { jsx } from "../jsx-runtime";
 
 export class ContextAccessor {
@@ -128,30 +131,101 @@ export class ComponentApi {
    * component. All context available to this component will be available to the
    * given component as well.
    */
-  public render(component: JSX.Element): string {
-    return jsxElemToHtmlSync(component, this, this.options);
+  public render(
+    component: JSX.Element,
+    optionsOverrides?: HtmlRenderOptions,
+  ): string {
+    const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      return jsxElemToHtmlSync(component, thisCopy, {
+        ...this.options,
+        ...optionsOverrides,
+      });
+    }
+    return jsxElemToHtmlSync(component, thisCopy, this.options);
   }
 
   public async renderAsync(
     component: JSX.Element | Promise<JSX.Element>,
+    optionsOverrides?: HtmlRenderOptions,
   ): Promise<string> {
     const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      return Promise.resolve(component).then((c) =>
+        jsxElemToHtmlAsync(c, thisCopy, {
+          ...this.options,
+          ...optionsOverrides,
+        })
+      );
+    }
     return Promise.resolve(component).then((c) =>
       jsxElemToHtmlAsync(c, thisCopy, this.options)
     );
   }
 
-  public renderToJson(component: JSX.Element) {
-    return jsxElemToJsonSync(component, this, this.options);
+  public renderToJson(
+    component: JSX.Element,
+    optionsOverrides?: JsonRenderOptions,
+  ) {
+    const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      return jsxElemToJsonSync(component, thisCopy, {
+        ...this.options,
+        ...optionsOverrides,
+      });
+    }
+    return jsxElemToJsonSync(component, thisCopy, this.options);
   }
 
   public async renderToJsonAsync(
     component: JSX.Element | Promise<JSX.Element>,
+    optionsOverrides?: JsonRenderOptions,
   ) {
     const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      return Promise.resolve(component).then((c) =>
+        jsxElemToJsonAsync(c, thisCopy, {
+          ...this.options,
+          ...optionsOverrides,
+        })
+      );
+    }
     return Promise.resolve(component).then((c) =>
       jsxElemToJsonAsync(c, thisCopy, this.options)
     );
+  }
+
+  public renderToDom(
+    window: Window,
+    component: JSX.Element,
+    optionsOverrides?: DomRenderOptions,
+  ) {
+    const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      const r = new DomRenderer(window, {
+        ...this.options,
+        ...optionsOverrides,
+      });
+      return r.render(component, thisCopy);
+    }
+    const r = new DomRenderer(window, this.options);
+    return r.render(component, thisCopy);
+  }
+
+  public async renderToDomAsync(
+    component: JSX.Element | Promise<JSX.Element>,
+    optionsOverrides?: DomRenderOptions,
+  ) {
+    const thisCopy = ComponentApi.clone(this);
+    if (optionsOverrides) {
+      const r = new DomRenderer(window, {
+        ...this.options,
+        ...optionsOverrides,
+      });
+      return Promise.resolve(component).then((c) => r.renderAsync(c, thisCopy));
+    }
+    const r = new DomRenderer(window, this.options);
+    return Promise.resolve(component).then((c) => r.renderAsync(c, thisCopy));
   }
 }
 

--- a/src/dom-renderer/dom-renderer.ts
+++ b/src/dom-renderer/dom-renderer.ts
@@ -1,3 +1,4 @@
+import type { ComponentApi } from "../component-api/component-api";
 import { type ElementGenerator, JsxteRenderer } from "../renderer/renderer";
 
 export type DomRenderOptions = {
@@ -66,21 +67,25 @@ export class DomRenderer {
     this.generator = new DomGenerator();
   }
 
-  public render(component: JSX.Element): HTMLElement | Text | DocumentFragment {
+  public render(
+    component: JSX.Element,
+    componentApi?: ComponentApi,
+  ): HTMLElement | Text | DocumentFragment {
     const renderer = new JsxteRenderer(this.generator, {
       ...this.options,
       allowAsync: false,
-    });
+    }, componentApi);
     return renderer.render(component);
   }
 
   public async renderAsync(
     component: JSX.Element,
+    componentApi?: ComponentApi,
   ): Promise<HTMLElement | Text | DocumentFragment> {
     const renderer = new JsxteRenderer(this.generator, {
       ...this.options,
       allowAsync: true,
-    });
+    }, componentApi);
     return renderer.render(component);
   }
 }


### PR DESCRIPTION
Added a `renderToDom` and `renderToDomAsync` options to the Component API.

Added the option to override the renderer options when calling any render method via the Component API.