### PR TITLE
feat: added an option to extend the allowed attribute type on all tags all at once

### DIFF
--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -14,11 +14,16 @@ export type HTMLProps<T extends object = never> = Rewrap<
   >
 >;
 
+type ExtendAllValues<T> = JSXTE.AttributeAcceptedTypes extends {
+  ALL: infer U;
+} ? T | U
+  : T;
+
 type ExtendBaseProps<P> = {
   [K in keyof P]: JSXTE.AttributeAcceptedTypes extends {
     [E in K]: infer T;
-  } ? T | P[K]
-    : P[K];
+  } ? ExtendAllValues<T | P[K]>
+    : ExtendAllValues<P[K]>;
 };
 
 declare global {


### PR DESCRIPTION
Added a new functionality that allows users to define a type that all attributes on all tags will accept.

```ts
class Box<T> {
  constructor(public v: T) {}

  toString() {
    return String(this.v);
  }
}

declare global {
  namespace JSXTE {
    interface AttributeAcceptedTypes {
      ALL: Box<any>;
    }
  }
}

// thanks to the interface declared above, the following will not raise errors:
const div = <div class={new Box(123)}></div>; // ok
```